### PR TITLE
Support positive feedback comments and fix organization IAM display

### DIFF
--- a/tests/unit/api/v1/test_message_feedback.py
+++ b/tests/unit/api/v1/test_message_feedback.py
@@ -14,6 +14,7 @@ ENDPOINT_FEEDBACK = (
     "/api/v1/platform-service/tenants/{tenant_id}/conversations/{conversation_id}/messages/{message_id}/feedback"
 )
 ENDPOINT_CONV_FEEDBACK = "/api/v1/platform-service/tenants/{tenant_id}/conversations/{conversation_id}/feedback"
+ENDPOINT_FEEDBACK_STATS = "/api/v1/platform-service/tenants/{tenant_id}/feedback/stats"
 
 
 def _setup_conversation(test_client: TestClient, user_token: Any) -> tuple[str, str, dict]:
@@ -137,3 +138,34 @@ class TestMessageFeedback:
             json={"rating": "THUMBS_UP", "reasons": [], "comment": None},
         )
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+class TestFeedbackStats:
+    """Tests for the aggregated feedback-stats endpoint."""
+
+    def test_stats_include_positive_and_negative(self, test_client: TestClient, test_user_token: Any) -> None:
+        tenant_id, conv_id, headers = _setup_conversation(test_client, test_user_token)
+        test_client.post(
+            ENDPOINT_FEEDBACK.format(tenant_id=tenant_id, conversation_id=conv_id, message_id="pos-1"),
+            json={"rating": "THUMBS_UP", "reasons": ["HELPFUL"], "comment": "very helpful"},
+            headers=headers,
+        )
+        test_client.post(
+            ENDPOINT_FEEDBACK.format(tenant_id=tenant_id, conversation_id=conv_id, message_id="neg-1"),
+            json={"rating": "THUMBS_DOWN", "reasons": ["INACCURATE"], "comment": "wrong"},
+            headers=headers,
+        )
+
+        response = test_client.get(
+            ENDPOINT_FEEDBACK_STATS.format(tenant_id=tenant_id),
+            headers=headers,
+        )
+        assert response.status_code == status.HTTP_200_OK
+        aggregate = response.json()["aggregate"]
+        assert aggregate["total_feedbacks"] == 2
+        assert aggregate["thumbs_up"] == 1
+        assert aggregate["thumbs_down"] == 1
+        assert len(aggregate["recent_negative"]) == 1
+        assert len(aggregate["recent_positive"]) == 1
+        assert aggregate["recent_positive"][0]["comment"] == "very helpful"
+        assert aggregate["recent_positive"][0]["rating"] == "THUMBS_UP"

--- a/tests/unit/api/v1/test_organizations.py
+++ b/tests/unit/api/v1/test_organizations.py
@@ -382,6 +382,39 @@ class TestOrganizationPrincipalRoutes:
         assert "id" in data
         assert "created_at" in data
 
+    def test_set_principal_resolves_display_name_when_added_org_first(self, test_client: TestClient) -> None:
+        """Adding a principal via org IAM first must resolve its display name from the IDP.
+
+        Regression test: previously the org add did not create a Principal row, so the
+        organization IAM list showed a raw principal_id instead of the display name until
+        the same principal was added at the tenant level.
+        """
+        user_token = test_client.create_test_user("org-prin-name-1", "Org Prin Name")
+        headers = create_auth_headers(user_token, use_cache=False)
+
+        org = _create_org(test_client, headers, identity_tenant_id="idp-name-set-1", slug="name-set-org")
+        org_id = org["id"]
+
+        test_client.post(
+            ENDPOINT_ORGANIZATION_PRINCIPALS.format(organization_id=org_id),
+            json={
+                "principal_id": "org-first-user",
+                "principal_type": PRINCIPAL_TYPE_USER,
+                "role": ROLE_ORG_TENANT_CREATOR,
+            },
+            headers=headers,
+        )
+
+        list_response = test_client.get(
+            ENDPOINT_ORGANIZATION_PRINCIPALS.format(organization_id=org_id), headers=headers
+        )
+        assert list_response.status_code == status.HTTP_200_OK
+        principals = list_response.json()["principals"]
+        added = next((p for p in principals if p["principal_id"] == "org-first-user"), None)
+        assert added is not None
+        assert added["display_name"] is not None
+        assert added["display_name"] != "org-first-user"
+
     def test_set_principal_multiple_roles(self, test_client: TestClient) -> None:
         """Test adding multiple roles to the same member."""
         user_token = test_client.create_test_user("org-prin-multi-1", "Org Prin Multi")

--- a/unifiedui/apis/v1/organizations.py
+++ b/unifiedui/apis/v1/organizations.py
@@ -165,7 +165,7 @@ async def set_organization_principal(
     """Add or set a principal role in the organization."""
     user: ContextIdentityUser = request.state.user
     user_id = user.identity.get_id()
-    return handler.set_principal(organization_id, principal_data, user_id)
+    return handler.set_principal(organization_id, principal_data, user_id, user)
 
 
 @router.delete(

--- a/unifiedui/core/database/enums.py
+++ b/unifiedui/core/database/enums.py
@@ -233,7 +233,7 @@ class MessageFeedbackRatingEnum(StrEnum):
 
 
 class MessageFeedbackReasonEnum(StrEnum):
-    """Structured reasons for message feedback."""
+    """Structured reasons for message feedback (negative and positive)."""
 
     HALLUCINATION = "HALLUCINATION"
     TOO_SLOW = "TOO_SLOW"
@@ -241,6 +241,11 @@ class MessageFeedbackReasonEnum(StrEnum):
     INACCURATE = "INACCURATE"
     INAPPROPRIATE = "INAPPROPRIATE"
     INCOMPLETE = "INCOMPLETE"
+    ACCURATE = "ACCURATE"
+    HELPFUL = "HELPFUL"
+    COMPLETE = "COMPLETE"
+    WELL_FORMATTED = "WELL_FORMATTED"
+    FAST = "FAST"
     OTHER = "OTHER"
 
     @classmethod

--- a/unifiedui/handlers/feedback_stats.py
+++ b/unifiedui/handlers/feedback_stats.py
@@ -118,6 +118,37 @@ class FeedbackStatsHandler:
                 for fb, agent_id, agent_name in recent_rows
             ]
 
+            recent_positive_stmt = (
+                select(
+                    MessageFeedback,
+                    Conversation.chat_agent_id,
+                    ChatAgent.name,
+                )
+                .outerjoin(Conversation, Conversation.id == MessageFeedback.conversation_id)
+                .outerjoin(ChatAgent, ChatAgent.id == Conversation.chat_agent_id)
+                .where(
+                    *base_filter,
+                    MessageFeedback.rating == MessageFeedbackRatingEnum.THUMBS_UP,
+                )
+                .order_by(MessageFeedback.created_at.desc())
+                .limit(100)
+            )
+            recent_positive_rows = session.execute(recent_positive_stmt).all()
+
+            recent_positive = [
+                RecentFeedbackEntry(
+                    message_id=fb.message_id,
+                    conversation_id=fb.conversation_id,
+                    chat_agent_id=agent_id,
+                    chat_agent_name=agent_name,
+                    rating=fb.rating,
+                    reasons=fb.reasons if fb.reasons else [],
+                    comment=fb.comment,
+                    created_at=fb.created_at.isoformat(),
+                )
+                for fb, agent_id, agent_name in recent_positive_rows
+            ]
+
             reason_counts: dict[str, int] = {}
             for fb, _agent_id, _agent_name in recent_rows:
                 if fb.reasons:
@@ -212,6 +243,7 @@ class FeedbackStatsHandler:
                 score=score,
                 reason_breakdown=reason_breakdown,
                 recent_negative=recent_negative,
+                recent_positive=recent_positive,
                 timeline=timeline,
             )
             return FeedbackStatsBatchResponse(aggregate=aggregate, per_agent=per_agent)

--- a/unifiedui/handlers/organizations.py
+++ b/unifiedui/handlers/organizations.py
@@ -315,6 +315,7 @@ class OrganizationHandler:
         organization_id: str,
         request: SetOrganizationPrincipalRequest,
         user_id: str,
+        user: ContextIdentityUser,
     ) -> OrganizationPrincipalRoleResponse:
         """Add or set a principal role in the organization.
 
@@ -322,6 +323,7 @@ class OrganizationHandler:
             organization_id: The organization ID
             request: Request containing principal_id, principal_type, and role
             user_id: The ID of the user making the change
+            user: The authenticated user context (for IDP access)
 
         Returns:
             OrganizationPrincipalRoleResponse with the created role entry
@@ -337,6 +339,14 @@ class OrganizationHandler:
 
         with self.db_client.get_session() as session:
             self._validate_organization_exists(session, organization_id)
+
+            self._ensure_principal_for_organization(
+                session=session,
+                organization_id=organization_id,
+                principal_id=request.principal_id,
+                principal_type=request.principal_type,
+                user=user,
+            )
 
             existing = session.execute(
                 select(OrganizationMember).where(
@@ -575,6 +585,59 @@ class OrganizationHandler:
         if not org:
             raise OrganizationNotFoundError(organization_id)
         return org
+
+    @staticmethod
+    def _ensure_principal_for_organization(
+        session: Session,
+        organization_id: str,
+        principal_id: str,
+        principal_type: str,
+        user: ContextIdentityUser,
+    ) -> None:
+        """Ensure a Principal row exists for a principal added at the organization level.
+
+        Principals are tenant-scoped, while organization membership is not. To make the
+        principal's display name resolvable in the organization IAM view, this anchors a
+        Principal row to a tenant belonging to the organization (reusing an existing row
+        from any of the org's tenants when present).
+
+        Args:
+            session: Database session
+            organization_id: The organization ID
+            principal_id: The principal to ensure
+            principal_type: The type of principal
+            user: The authenticated user context (for IDP access)
+        """
+        existing = session.execute(
+            select(Principal.principal_id)
+            .where(
+                Principal.tenant_id.in_(select(Tenant.id).where(Tenant.organization_id == organization_id)),
+                Principal.principal_id == principal_id,
+            )
+            .limit(1)
+        ).scalar_one_or_none()
+
+        if existing:
+            return
+
+        anchor_tenant_id = session.execute(
+            select(Tenant.id).where(Tenant.organization_id == organization_id).limit(1)
+        ).scalar_one_or_none()
+
+        if anchor_tenant_id is None:
+            logger.warning(
+                "Cannot resolve principal display name: organization has no tenants",
+                extra={"organization_id": organization_id, "principal_id": principal_id},
+            )
+            return
+
+        ensure_principal_exists(
+            session=session,
+            tenant_id=anchor_tenant_id,
+            principal_id=principal_id,
+            principal_type=principal_type,
+            user=user,
+        )
 
     @staticmethod
     def _org_to_response(org: Organization) -> OrganizationResponse:

--- a/unifiedui/schema/responses/feedback_stats.py
+++ b/unifiedui/schema/responses/feedback_stats.py
@@ -40,6 +40,7 @@ class FeedbackStatsResponse(BaseModel):
     score: float | None
     reason_breakdown: list[ReasonBreakdownEntry]
     recent_negative: list[RecentFeedbackEntry]
+    recent_positive: list[RecentFeedbackEntry] = []
     timeline: list[FeedbackTimelineEntry]
 
 


### PR DESCRIPTION
This pull request introduces two main improvements: (1) it enhances the feedback statistics endpoint to include recent positive feedback entries and expands the set of structured feedback reasons, and (2) it ensures that organization-level principal additions always resolve display names by anchoring a `Principal` row to an organization tenant. These changes are covered by new and updated unit tests.

**Feedback statistics improvements:**

* The feedback stats endpoint now returns a `recent_positive` field listing recent positive feedback entries, in addition to the existing `recent_negative` field. This includes API, handler, schema, and test updates. [[1]](diffhunk://#diff-8c199079349ac7d144c30fed10113f9fa6416c287e397000a84de36df3b32a19R121-R151) [[2]](diffhunk://#diff-8c199079349ac7d144c30fed10113f9fa6416c287e397000a84de36df3b32a19R246) [[3]](diffhunk://#diff-72624b5923849a3a5f5b38b65b6d36d5e5008506fe8b16479b4306f2934da538R43) [[4]](diffhunk://#diff-7632ed189ca89412a1dc3a16125bfa01d96af69c0801fb1a0835000f5b0caa63R17) [[5]](diffhunk://#diff-7632ed189ca89412a1dc3a16125bfa01d96af69c0801fb1a0835000f5b0caa63R141-R171)
* The `MessageFeedbackReasonEnum` now includes positive reasons such as `ACCURATE`, `HELPFUL`, `COMPLETE`, `WELL_FORMATTED`, and `FAST`, making feedback more expressive.

**Organization principal display name resolution:**

* When adding a principal at the organization level, the system now ensures a corresponding `Principal` row exists (anchored to any tenant in the organization), allowing display names to be resolved immediately in the organization IAM list. This involves changes to handler logic, method signatures, and a new static helper. [[1]](diffhunk://#diff-515153d003345ed62a2c624654561eb8aaf15536f19a1ffe22bad9fb5687a541L168-R168) [[2]](diffhunk://#diff-206f6222a438e49096da8e1cf97455c70d2540ec8a837cbb5b6d4e850786d261R318-R326) [[3]](diffhunk://#diff-206f6222a438e49096da8e1cf97455c70d2540ec8a837cbb5b6d4e850786d261R343-R350) [[4]](diffhunk://#diff-206f6222a438e49096da8e1cf97455c70d2540ec8a837cbb5b6d4e850786d261R589-R641)
* A new regression test verifies that display names are resolved when adding a principal via the organization IAM endpoint before tenant-level addition.